### PR TITLE
Request Parameters are not copied into new Request on forward

### DIFF
--- a/Security/Http/EntryPoint/OAuthEntryPoint.php
+++ b/Security/Http/EntryPoint/OAuthEntryPoint.php
@@ -69,7 +69,8 @@ class OAuthEntryPoint implements AuthenticationEntryPointInterface
     {
         if ($this->useForward) {
             $subRequest = $this->httpUtils->createRequest($request, $this->loginPath);
-
+            $subRequest->query->add($request->query->getIterator()->getArrayCopy());
+            
             $response = $this->httpKernel->handle($subRequest, HttpKernelInterface::SUB_REQUEST);
             if (200 === $response->getStatusCode()) {
                 $response->headers->set('X-Status-Code', 401);


### PR DESCRIPTION
Added line to copy query parameters from incoming request to new request on forward only
